### PR TITLE
feat: add theming capabilities

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,11 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- Inter Font -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,8 @@ import { HelmetProvider } from 'react-helmet-async';
 
 import { configureAppStore } from 'store/configureStore';
 
+import { ThemeProvider } from 'styles/theme/ThemeProvider';
+
 import reportWebVitals from 'reportWebVitals';
 
 // Initialize languages
@@ -34,11 +36,13 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <Provider store={store}>
-    <HelmetProvider>
-      <React.StrictMode>
-        <App />
-      </React.StrictMode>
-    </HelmetProvider>
+    <ThemeProvider>
+      <HelmetProvider>
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      </HelmetProvider>
+    </ThemeProvider>
   </Provider>,
 );
 

--- a/src/styles/StyleConstants.ts
+++ b/src/styles/StyleConstants.ts
@@ -1,0 +1,3 @@
+export const enum StyleConstants {
+  NAV_BAR_HEIGHT = '6rem',
+}

--- a/src/styles/global-styles.ts
+++ b/src/styles/global-styles.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { StyleConstants } from './StyleConstants';
 
 export const GlobalStyle = createGlobalStyle`
   html,
@@ -8,7 +9,9 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Inter', Helvetica, Arial, sans-serif;
+    padding-top: ${StyleConstants.NAV_BAR_HEIGHT};
+    background: ${p => p.theme.backgroundGradient};
   }
 
   #root {

--- a/src/styles/theme/ThemeProvider.tsx
+++ b/src/styles/theme/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { ThemeProvider as OriginalThemeProvider } from 'styled-components';
+import { useSelector } from 'react-redux';
+import { useThemeSlice } from './slice';
+import { selectTheme } from './slice/selectors';
+
+export const ThemeProvider = (props: { children: React.ReactChild }) => {
+  useThemeSlice();
+
+  const theme = useSelector(selectTheme);
+  return (
+    <OriginalThemeProvider theme={theme}>
+      {React.Children.only(props.children)}
+    </OriginalThemeProvider>
+  );
+};

--- a/src/styles/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/styles/theme/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { Store } from '@reduxjs/toolkit';
+import { ThemeProvider } from '../ThemeProvider';
+import { configureAppStore } from 'store/configureStore';
+import { useTheme } from 'styled-components';
+import { selectTheme } from '../slice/selectors';
+
+const renderThemeProvider = (store: Store, Child: React.FunctionComponent) =>
+  render(
+    <Provider store={store}>
+      <ThemeProvider>
+        <Child />
+      </ThemeProvider>
+    </Provider>,
+  );
+
+describe('<ThemeProvider />', () => {
+  let store: ReturnType<typeof configureAppStore>;
+
+  beforeEach(() => {
+    store = configureAppStore();
+  });
+
+  it('should render its children', () => {
+    const text = 'Test';
+    const children = () => <h1>{text}</h1>;
+    const { queryByText } = renderThemeProvider(store, children);
+    expect(queryByText(text)).toBeInTheDocument();
+  });
+
+  it('should render selected theme', () => {
+    let theme: any;
+    const children = () => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      theme = useTheme();
+      return <h1>a</h1>;
+    };
+    renderThemeProvider(store, children);
+    expect(theme).toBe(selectTheme(store.getState() as any));
+  });
+});

--- a/src/styles/theme/__tests__/utils.test.ts
+++ b/src/styles/theme/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import * as utils from '../utils';
+
+describe('theme utils', () => {
+  it('should get storage item', () => {
+    utils.saveTheme('system');
+    expect(utils.getThemeFromStorage()).toBe('system');
+  });
+  it('should check system theme', () => {
+    expect(utils.isSystemDark).toBeUndefined();
+  });
+});

--- a/src/styles/theme/slice/__tests__/slice.test.ts
+++ b/src/styles/theme/slice/__tests__/slice.test.ts
@@ -1,0 +1,54 @@
+import * as slice from '..';
+import { ThemeState, ThemeKeyType } from '../types';
+import { RootState } from 'types';
+import { themes } from '../../themes';
+import { DefaultTheme } from 'styled-components';
+import { selectTheme, selectThemeKey } from '../selectors';
+
+describe('theme slice', () => {
+  let state: ThemeState;
+
+  beforeEach(() => {
+    state = slice.initialState;
+  });
+
+  it('should return the initial state', () => {
+    expect(slice.reducer(undefined, { type: '' })).toEqual(state);
+  });
+
+  it('should changeTheme', () => {
+    expect(
+      slice.reducer(state, slice.themeActions.changeTheme('dark')),
+    ).toEqual<ThemeState>({ selected: 'dark' });
+  });
+
+  describe('selectors', () => {
+    it('selectTheme', () => {
+      let state: RootState = {};
+      expect(selectTheme(state)).toEqual<DefaultTheme>(themes.light);
+      state = {
+        theme: { selected: 'system' },
+      };
+      expect(selectTheme(state)).toEqual<DefaultTheme>(themes.light);
+
+      state = {
+        theme: { selected: 'dark' },
+      };
+      expect(selectTheme(state)).toEqual<DefaultTheme>(themes.dark);
+    });
+
+    it('selectThemeKey', () => {
+      let state: RootState = {};
+      expect(selectThemeKey(state)).toEqual<ThemeKeyType>(
+        slice.initialState.selected,
+      );
+
+      state = {
+        theme: { selected: 'system' },
+      };
+      expect(selectThemeKey(state)).toEqual<ThemeKeyType>(
+        state.theme!.selected,
+      );
+    });
+  });
+});

--- a/src/styles/theme/slice/index.ts
+++ b/src/styles/theme/slice/index.ts
@@ -1,0 +1,26 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from 'utils/@reduxjs/toolkit';
+import { useInjectReducer } from 'utils/redux-injectors';
+import { getThemeFromStorage } from '../utils';
+import { ThemeKeyType, ThemeState } from './types';
+
+export const initialState: ThemeState = {
+  selected: getThemeFromStorage() || 'system',
+};
+
+const slice = createSlice({
+  name: 'theme',
+  initialState,
+  reducers: {
+    changeTheme(state, action: PayloadAction<ThemeKeyType>) {
+      state.selected = action.payload;
+    },
+  },
+});
+
+export const { actions: themeActions, reducer } = slice;
+
+export const useThemeSlice = () => {
+  useInjectReducer({ key: slice.name, reducer: slice.reducer });
+  return { actions: slice.actions };
+};

--- a/src/styles/theme/slice/selectors.ts
+++ b/src/styles/theme/slice/selectors.ts
@@ -1,0 +1,21 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import { RootState } from 'types';
+import { initialState } from '.';
+import { themes } from '../themes';
+import { isSystemDark } from '../utils';
+
+export const selectTheme = createSelector(
+  [(state: RootState) => state.theme || initialState],
+  theme => {
+    if (theme.selected === 'system') {
+      return isSystemDark ? themes.dark : themes.light;
+    }
+    return themes[theme.selected];
+  },
+);
+
+export const selectThemeKey = createSelector(
+  [(state: RootState) => state.theme || initialState],
+  theme => theme.selected,
+);

--- a/src/styles/theme/slice/types.ts
+++ b/src/styles/theme/slice/types.ts
@@ -1,0 +1,7 @@
+import { themes } from '../themes';
+
+export type ThemeKeyType = keyof typeof themes | 'system';
+
+export interface ThemeState {
+  selected: ThemeKeyType;
+}

--- a/src/styles/theme/styled.d.ts
+++ b/src/styles/theme/styled.d.ts
@@ -1,0 +1,7 @@
+import 'styled-components';
+import { Theme } from './themes';
+
+/* This is the suggested way of declaring theme types */
+declare module 'styled-components' {
+  export interface DefaultTheme extends Theme {}
+}

--- a/src/styles/theme/themes.ts
+++ b/src/styles/theme/themes.ts
@@ -1,0 +1,35 @@
+export type Theme = {
+  primary: string;
+  brand: string;
+  brandHover: string;
+  text: string;
+  textSecondary: string;
+  background: string;
+  backgroundVariant: string;
+  backgroundGradient: string;
+  border: string;
+  borderLight: string;
+};
+
+const darkTheme: Theme = {
+  primary: 'rgba(28, 28, 40, 1)',
+  brand: 'rgba(105, 102, 255, 1)',
+  brandHover: 'rgba(123, 120, 255, 1)',
+  borderLight: 'rgba(241, 233, 231, 0.05)',
+  text: 'rgba(255, 255, 255, 1)',
+  textSecondary: 'rgba(200, 199, 216, 1)',
+  background: 'rgba(28, 28, 40, 1)',
+  backgroundVariant: 'rgba(57, 57, 83, 1)',
+  backgroundGradient: `
+    linear-gradient(193.53deg, #2C2C3D -7.66%, #1A1A27 79.5%);
+  `,
+  border: `
+    linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0) 100%); 
+    background-blend-mode: soft-light;
+  `,
+};
+
+export const themes = {
+  light: darkTheme,
+  dark: darkTheme,
+};

--- a/src/styles/theme/utils.ts
+++ b/src/styles/theme/utils.ts
@@ -1,0 +1,17 @@
+import { ThemeKeyType } from './slice/types';
+
+/* istanbul ignore next line */
+export const isSystemDark = window?.matchMedia
+  ? window.matchMedia('(prefers-color-scheme: dark)')?.matches
+  : undefined;
+
+export function saveTheme(theme: ThemeKeyType) {
+  window.localStorage && localStorage.setItem('selectedTheme', theme);
+}
+
+/* istanbul ignore next line */
+export function getThemeFromStorage(): ThemeKeyType | null {
+  return window.localStorage
+    ? (localStorage.getItem('selectedTheme') as ThemeKeyType) || null
+    : null;
+}

--- a/src/types/RootState.ts
+++ b/src/types/RootState.ts
@@ -1,9 +1,11 @@
 // [IMPORT NEW CONTAINERSTATE ABOVE] < Needed for generating containers seamlessly
 
+import { ThemeState } from 'styles/theme/slice/types';
+
 /* 
   Because the redux-injectors injects your reducers asynchronously somewhere in your code
   You have to declare them here manually
 */
 export interface RootState {
-  // [INSERT NEW REDUCER KEY ABOVE] < Needed for generating containers seamlessly
+  theme?: ThemeState;
 }


### PR DESCRIPTION
## Overview
- Adds a theme slice & context provider which is available to all routes. 
- Defines a basic theme using colors from original figma design. 

## Examples
This theme contains the colors you see in the image below:
![image](https://user-images.githubusercontent.com/24196928/230797522-1fec2f12-1ae4-4452-9167-82698206d889.png)
