### PR TITLE
Feat navigation bear

### DIFF
--- a/src/app/components/ButtonPrimary/styles.ts
+++ b/src/app/components/ButtonPrimary/styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const ButtonPrimary = styled.button`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 16px;
+  gap: 10px;
+  border: none;
+  user-select: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+
+  width: 99px;
+  height: 48px;
+
+  /* Accent/Brand */
+
+  background: ${p => p.theme.brand};
+  color: ${p => p.theme.text};
+  border-radius: 7.29px;
+
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 24px;
+
+  :hover {
+    background-color: ${p => p.theme.brandHover};
+  }
+`;

--- a/src/app/components/NavigationHeader/NavigationItems/styles.ts
+++ b/src/app/components/NavigationHeader/NavigationItems/styles.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const NavigationItems = styled.div`
+  height: 48px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+  align-self: stretch;
+`;

--- a/src/app/components/NavigationHeader/NavigationLinks/styles.ts
+++ b/src/app/components/NavigationHeader/NavigationLinks/styles.ts
@@ -1,0 +1,26 @@
+import { Link } from 'app/components/Typography/Link/styles';
+import styled from 'styled-components';
+
+export const NavigationLinks = styled.div`
+  display: flex;
+`;
+
+export const NavigationLink = styled(Link)`
+  display: flex;
+  padding: 0.25rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  align-items: center;
+
+  .icon {
+    margin-right: 0.25rem;
+  }
+
+  :last-of-type {
+    margin-right: 1rem;
+  }
+`;
+
+export const NavigationIcon = styled.span`
+  padding-right: 5px;
+`;

--- a/src/app/components/NavigationHeader/index.tsx
+++ b/src/app/components/NavigationHeader/index.tsx
@@ -1,0 +1,62 @@
+import { ButtonPrimary } from '../ButtonPrimary/styles';
+import { Brand } from '../Typography/Brand/styles';
+import { NavigationItems } from './NavigationItems/styles';
+import {
+  NavigationIcon,
+  NavigationLink,
+  NavigationLinks,
+} from './NavigationLinks/styles';
+import { NavigationHeaderWrapper } from './styles';
+import { NavPage } from './types';
+
+export const NavigationHeader = () => {
+  const pages: NavPage[] = [
+    {
+      url: '#',
+      name: 'DAO',
+      alt: 'DAO',
+      icon: <span />,
+    },
+    {
+      url: '#',
+      name: 'Marketplace',
+      alt: 'Marketplace',
+      icon: <span />,
+    },
+    {
+      url: '#',
+      name: 'Documentation',
+      alt: 'Documentation',
+      icon: <span />,
+    },
+    {
+      url: '#',
+      name: 'FAQ',
+      alt: 'Frequently Asked Questions',
+      icon: <span />,
+    },
+  ];
+
+  return (
+    <NavigationHeaderWrapper>
+      <NavigationItems>
+        <Brand>Tezos Legends</Brand>
+        <NavigationLinks>
+          {pages.map((page, index) => (
+            <NavigationLink
+              key={index}
+              to={page.url}
+              target="_blank"
+              title={page.alt}
+              rel="noopener noreferrer"
+            >
+              <NavigationIcon>{page.icon}</NavigationIcon>
+              {page.name}
+            </NavigationLink>
+          ))}
+          <ButtonPrimary>Connect</ButtonPrimary>
+        </NavigationLinks>
+      </NavigationItems>
+    </NavigationHeaderWrapper>
+  );
+};

--- a/src/app/components/NavigationHeader/styles.ts
+++ b/src/app/components/NavigationHeader/styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+console.log(`${p => p.theme}`);
+
+export const NavigationHeaderWrapper = styled.header`
+  width: 100%;
+  height: 96px;
+  top: 0;
+  padding: 0 1.5rem;
+  display: flex;
+  position: fixed;
+  justify-content: center;
+  flex-direction: column;
+  box-shadow: 0 1px 0 0 ${p => p.theme.borderLight};
+  z-index: 2;
+
+  @supports (backdrop-filter: blur(10px)) {
+    backdrop-filter: blur(10px);
+  }
+`;

--- a/src/app/components/NavigationHeader/types.ts
+++ b/src/app/components/NavigationHeader/types.ts
@@ -1,0 +1,6 @@
+export interface NavPage {
+  url: string;
+  name: string;
+  alt: string;
+  icon: React.ReactElement;
+}

--- a/src/app/components/Typography/Brand/styles.ts
+++ b/src/app/components/Typography/Brand/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import { H1 } from '../H1/styles';
+
+export const Brand = styled(H1)`
+  font-weight: 600;
+  //font-style: normal;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+`;

--- a/src/app/components/Typography/H1/styles.ts
+++ b/src/app/components/Typography/H1/styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const H1 = styled.h1`
+  color: ${p => p.theme.textSecondary};
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;

--- a/src/app/components/Typography/Link/styles.ts
+++ b/src/app/components/Typography/Link/styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { Link as RouterLink } from 'react-router-dom';
+
+export const Link = styled(RouterLink)`
+  text-decoration: none;
+  color: ${p => p.theme.textSecondary};
+`;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -15,6 +15,7 @@ import { GlobalStyle } from 'styles/global-styles';
 import { HomePage } from './pages/HomePage/Loadable';
 import { NotFoundPage } from './components/NotFoundPage/Loadable';
 import { useTranslation } from 'react-i18next';
+import { NavigationHeader } from './components/NavigationHeader';
 
 export function App() {
   const { i18n } = useTranslation();
@@ -27,7 +28,7 @@ export function App() {
       >
         <meta name="description" content="A React Boilerplate application" />
       </Helmet>
-
+      <NavigationHeader />
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="*" element={<NotFoundPage />} />

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
+import { AppWrapper } from './styles';
 
 export function HomePage() {
   return (
@@ -8,7 +9,9 @@ export function HomePage() {
         <title>HomePage</title>
         <meta name="description" content="A Boilerplate application homepage" />
       </Helmet>
-      <span>My HomePage</span>
+      <AppWrapper>
+        <span>My HomePage</span>
+      </AppWrapper>
     </>
   );
 }

--- a/src/app/pages/HomePage/styles.ts
+++ b/src/app/pages/HomePage/styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import { StyleConstants } from 'styles/StyleConstants';
+
+export const AppWrapper = styled.div`
+  width: 100%;
+  height: calc(100vh - ${StyleConstants.NAV_BAR_HEIGHT});
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  grid-template-rows: 1fr auto;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  justify-items: center;
+`;


### PR DESCRIPTION
## Overview
- Adds a theme slice & context provider which is available to all routes. 
- Defines a basic theme using colors from original figma design. 

## Test plan
- clone this branch
- run `yarn start`
- assert that you see a navbar fixed to the top of the page
- assert that nav bar contains the following items: `dao, marketplace, faq, documentation, connect button`

## Example of result

![image](https://user-images.githubusercontent.com/24196928/230798109-f20699cc-84fe-48d7-a53a-f2d810368dc2.png)
