### PR TITLE
feat: basic wireframe for nft card

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "1.8.5",
+    "@stdlib/string-truncate-middle": "0.0.3",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.4.0",
     "@types/fontfaceobserver": "^2.1.0",

--- a/src/app/components/CardPrimary/styles.ts
+++ b/src/app/components/CardPrimary/styles.ts
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+export const CardPrimary = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  width: 380px;
+  height: 380px;
+  background: ${p => p.theme.backgroundGradient};
+  border: double 4px transparent;
+  border-radius: 1rem;
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
+
+export const GridBackground = styled.div`
+  width: 100%;
+  height: 100%;
+  background-repeat: repeat;
+  background-color: transparent;
+  background-size: 15px 15px;
+  background-image: linear-gradient(
+      0deg,
+      transparent 24%,
+      ${p => p.theme.backgroundVariant} 25%,
+      ${p => p.theme.backgroundVariant} 26%,
+      transparent 27%,
+      transparent 74%,
+      ${p => p.theme.backgroundVariant} 75%,
+      ${p => p.theme.backgroundVariant} 76%,
+      transparent 77%,
+      transparent
+    ),
+    linear-gradient(
+      90deg,
+      transparent 24%,
+      ${p => p.theme.backgroundVariant} 25%,
+      ${p => p.theme.backgroundVariant} 26%,
+      transparent 27%,
+      transparent 74%,
+      ${p => p.theme.backgroundVariant} 75%,
+      ${p => p.theme.backgroundVariant} 76%,
+      transparent 77%,
+      transparent
+    );
+`;
+
+export const CardImage = styled.div`
+  width: 100%;
+  height: 50%;
+`;

--- a/src/app/components/CardPrimary/styles.ts
+++ b/src/app/components/CardPrimary/styles.ts
@@ -15,6 +15,15 @@ export const CardPrimary = styled.div`
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 `;
 
+export const CardDetails = styled.div`
+  width: 100%;
+  height: 50%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
 export const GridBackground = styled.div`
   width: 100%;
   height: 100%;

--- a/src/app/pages/HomePage/components/NftCard/index.tsx
+++ b/src/app/pages/HomePage/components/NftCard/index.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { CardImage, GridBackground } from 'app/components/CardPrimary/styles';
+import { Card, NftImage, NftImageDisplay } from './styles';
+
+export const NftCard = () => {
+  // todo: should use base64 svg
+  const [nftImageUrl, setNftImageUrl] = useState<string | undefined>(
+    'https://i.imgur.com/tKpyIKV.png',
+  );
+
+  return (
+    <Card>
+      <CardImage>
+        <GridBackground>
+          <NftImageDisplay>
+            <NftImage src={nftImageUrl} />
+          </NftImageDisplay>
+        </GridBackground>
+      </CardImage>
+    </Card>
+  );
+};

--- a/src/app/pages/HomePage/components/NftCard/index.tsx
+++ b/src/app/pages/HomePage/components/NftCard/index.tsx
@@ -1,11 +1,44 @@
 import { useState } from 'react';
-import { CardImage, GridBackground } from 'app/components/CardPrimary/styles';
-import { Card, NftImage, NftImageDisplay } from './styles';
+import {
+  CardDetails,
+  CardImage,
+  GridBackground,
+} from 'app/components/CardPrimary/styles';
+import {
+  BidDetails,
+  BidDetailsAvatar,
+  BidDetailsAvatarImg,
+  BidDetailsBidderName,
+  BidDetailsHeader,
+  BidDetailsLastBid,
+  BidDetailsTitle,
+  Card,
+  LastBidAmount,
+  LastBidTime,
+  NftDate,
+  NftDescription,
+  NftDetails,
+  NftId,
+  NftImage,
+  NftImageDisplay,
+  NftTitle,
+  ProgressBar,
+  ProgressBarFill,
+} from './styles';
+import truncateMiddle from '@stdlib/string-truncate-middle/';
 
 export const NftCard = () => {
+  const [activeBidder, setActiveBidder] = useState<string | undefined>(
+    truncateMiddle('tz1RLomvUivaCNUmec7gALquhGMu5PgzMvkP', 16),
+  );
+
   // todo: should use base64 svg
   const [nftImageUrl, setNftImageUrl] = useState<string | undefined>(
     'https://i.imgur.com/tKpyIKV.png',
+  );
+
+  const [bidderAvatar, setBidderAvatarUrl] = useState<string | undefined>(
+    'https://services.tzkt.io/v1/avatars/tz1RLomvUivaCNUmec7gALquhGMu5PgzMvkP',
   );
 
   return (
@@ -17,6 +50,31 @@ export const NftCard = () => {
           </NftImageDisplay>
         </GridBackground>
       </CardImage>
+      <CardDetails>
+        <NftDetails>
+          <NftDescription>
+            <NftTitle>Tezos Legends</NftTitle>
+            <NftId>#001</NftId>
+          </NftDescription>
+          <NftDate>Apr 9, 2023</NftDate>
+        </NftDetails>
+        <BidDetails>
+          <BidDetailsHeader>
+            <BidDetailsTitle>Active bid</BidDetailsTitle>
+            <BidDetailsAvatar>
+              <BidDetailsAvatarImg src={bidderAvatar} alt="Highest Bidder" />
+            </BidDetailsAvatar>
+          </BidDetailsHeader>
+          <BidDetailsBidderName>{activeBidder}</BidDetailsBidderName>
+          <BidDetailsLastBid>
+            <LastBidAmount>125ꜩ</LastBidAmount>
+            <LastBidTime>15m ago</LastBidTime>
+          </BidDetailsLastBid>
+          <ProgressBar>
+            <ProgressBarFill progress={35}> </ProgressBarFill>
+          </ProgressBar>
+        </BidDetails>
+      </CardDetails>
     </Card>
   );
 };

--- a/src/app/pages/HomePage/components/NftCard/index.tsx
+++ b/src/app/pages/HomePage/components/NftCard/index.tsx
@@ -26,10 +26,11 @@ import {
   ProgressBarFill,
 } from './styles';
 import truncateMiddle from '@stdlib/string-truncate-middle/';
+import styled from 'styled-components';
 
 export const NftCard = () => {
   const [activeBidder, setActiveBidder] = useState<string | undefined>(
-    truncateMiddle('tz1RLomvUivaCNUmec7gALquhGMu5PgzMvkP', 16),
+    truncateMiddle('tz1RLomvUivaCNUmec7gALquhGMu5PgzMvkP', 12),
   );
 
   // todo: should use base64 svg
@@ -42,39 +43,55 @@ export const NftCard = () => {
   );
 
   return (
-    <Card>
-      <CardImage>
-        <GridBackground>
-          <NftImageDisplay>
-            <NftImage src={nftImageUrl} />
-          </NftImageDisplay>
-        </GridBackground>
-      </CardImage>
-      <CardDetails>
-        <NftDetails>
-          <NftDescription>
-            <NftTitle>Tezos Legends</NftTitle>
-            <NftId>#001</NftId>
-          </NftDescription>
-          <NftDate>Apr 9, 2023</NftDate>
-        </NftDetails>
-        <BidDetails>
-          <BidDetailsHeader>
-            <BidDetailsTitle>Active bid</BidDetailsTitle>
-            <BidDetailsAvatar>
-              <BidDetailsAvatarImg src={bidderAvatar} alt="Highest Bidder" />
-            </BidDetailsAvatar>
-          </BidDetailsHeader>
-          <BidDetailsBidderName>{activeBidder}</BidDetailsBidderName>
-          <BidDetailsLastBid>
-            <LastBidAmount>125ꜩ</LastBidAmount>
-            <LastBidTime>15m ago</LastBidTime>
-          </BidDetailsLastBid>
-          <ProgressBar>
-            <ProgressBarFill progress={35}> </ProgressBarFill>
-          </ProgressBar>
-        </BidDetails>
-      </CardDetails>
-    </Card>
+    <Wrapper>
+      <Card>
+        <CardImage>
+          <GridBackground>
+            <NftImageDisplay>
+              <NftImage src={nftImageUrl} />
+            </NftImageDisplay>
+          </GridBackground>
+        </CardImage>
+        <CardDetails>
+          <NftDetails>
+            <NftDescription>
+              <NftTitle>Tezos Legends</NftTitle>
+              <NftId>#001</NftId>
+            </NftDescription>
+            <NftDate>Apr 9, 2023</NftDate>
+          </NftDetails>
+          <BidDetails>
+            <BidDetailsHeader>
+              <BidDetailsTitle>Active bid</BidDetailsTitle>
+            </BidDetailsHeader>
+            <span
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              <BidDetailsBidderName>{activeBidder}</BidDetailsBidderName>
+              <BidDetailsAvatar>
+                <BidDetailsAvatarImg src={bidderAvatar} alt="Highest Bidder" />
+              </BidDetailsAvatar>
+            </span>
+
+            <BidDetailsLastBid>
+              <LastBidAmount>125ꜩ</LastBidAmount>
+              <LastBidTime>15m ago</LastBidTime>
+            </BidDetailsLastBid>
+            <ProgressBar>
+              <ProgressBarFill progress={35}> </ProgressBarFill>
+            </ProgressBar>
+          </BidDetails>
+        </CardDetails>
+      </Card>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  height: 100%;
+`;

--- a/src/app/pages/HomePage/components/NftCard/styles.ts
+++ b/src/app/pages/HomePage/components/NftCard/styles.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
-import { CardPrimary } from 'app/components/CardPrimary/styles';
+import { CardDetails, CardPrimary } from 'app/components/CardPrimary/styles';
+import { H1 } from 'app/components/Typography/H1/styles';
+import { ReactNode } from 'react';
 
 export const Card = styled(CardPrimary)`
   display: flex;
@@ -24,4 +26,124 @@ export const NftImage = styled.img`
   position: absolute;
   z-index: 1;
   bottom: 0;
+`;
+
+export const NftDetails = styled.div`
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const NftDescription = styled.div`
+  display: block;
+`;
+
+export const NftTitle = styled(H1)`
+  padding: 0;
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 400;
+`;
+
+export const NftId = styled(H1)`
+  padding: 0;
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+`;
+
+export const NftDate = styled(H1)`
+  font-size: 1rem;
+  font-weight: 400;
+  padding: 0;
+  margin: 0;
+`;
+
+export const BidDetails = styled(CardPrimary)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 50%;
+  height: 100%;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 7.95px;
+  box-shadow: none;
+`;
+
+export const BidDetailsHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+export const BidDetailsTitle = styled(H1)`
+  font-size: 1rem;
+  font-weight: 400;
+  padding: 0;
+  margin: 0;
+`;
+
+export const BidDetailsAvatar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border-radius: 50%;
+  background-color: ${p => p.theme.backgroundVariant};
+  border: double 1px ${p => p.theme.brand};
+  overflow: hidden;
+`;
+
+export const BidDetailsAvatarImg = styled.img`
+  width: 1.75rem;
+  height: 1.75rem;
+`;
+
+export const BidDetailsBidderName = styled(BidDetailsTitle)`
+  color: ${p => p.theme.textTertiary};
+`;
+
+export const BidDetailsLastBid = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+export const LastBidAmount = styled(BidDetailsTitle)`
+  color: ${p => p.theme.text};
+  font-size: 1rem;
+  font-weight: 600;
+`;
+
+export const LastBidTime = styled(LastBidAmount)`
+  color: ${p => p.theme.textTertiary};
+  font-weight: 400;
+`;
+
+export const ProgressBar = styled.div`
+  width: 100%;
+  height: 1rem;
+  border-radius: 100px;
+  background: ${p => p.theme.backgroundVariant};
+  overflow: hidden;
+`;
+
+type ProgressBarFillProps = {
+  progress: number;
+  children: ReactNode;
+};
+
+export const ProgressBarFill = styled.div<ProgressBarFillProps>`
+  width: ${({ progress }) => (progress ? `${progress}%` : 0)};
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem;
+  background: ${p => p.theme.brand};
 `;

--- a/src/app/pages/HomePage/components/NftCard/styles.ts
+++ b/src/app/pages/HomePage/components/NftCard/styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { CardPrimary } from 'app/components/CardPrimary/styles';
+
+export const Card = styled(CardPrimary)`
+  display: flex;
+  flex-direction: column;
+  max-width: 380px;
+  max-height: 380px;
+`;
+
+export const NftImageDisplay = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 0;
+`;
+
+export const NftImage = styled.img`
+  max-width: 100%;
+  height: auto;
+  position: absolute;
+  z-index: 1;
+  bottom: 0;
+`;

--- a/src/app/pages/HomePage/components/NftCard/styles.ts
+++ b/src/app/pages/HomePage/components/NftCard/styles.ts
@@ -92,7 +92,6 @@ export const BidDetailsAvatar = styled.div`
   justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
-  padding: 0;
   border-radius: 50%;
   background-color: ${p => p.theme.backgroundVariant};
   border: double 1px ${p => p.theme.brand};
@@ -102,6 +101,7 @@ export const BidDetailsAvatar = styled.div`
 export const BidDetailsAvatarImg = styled.img`
   width: 1.75rem;
   height: 1.75rem;
+  padding: 0.1rem;
 `;
 
 export const BidDetailsBidderName = styled(BidDetailsTitle)`
@@ -111,8 +111,8 @@ export const BidDetailsBidderName = styled(BidDetailsTitle)`
 export const BidDetailsLastBid = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   width: 100%;
+  justify-content: space-between;
 `;
 
 export const LastBidAmount = styled(BidDetailsTitle)`
@@ -124,6 +124,11 @@ export const LastBidAmount = styled(BidDetailsTitle)`
 export const LastBidTime = styled(LastBidAmount)`
   color: ${p => p.theme.textTertiary};
   font-weight: 400;
+`;
+
+export const LastBidArrow = styled.span`
+  color: ${p => p.theme.green};
+  font-weight: 600;
 `;
 
 export const ProgressBar = styled.div`

--- a/src/app/pages/HomePage/index.tsx
+++ b/src/app/pages/HomePage/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { AppWrapper } from './styles';
+import { NftCard } from './components/NftCard';
 
 export function HomePage() {
   return (
@@ -10,7 +11,7 @@ export function HomePage() {
         <meta name="description" content="A Boilerplate application homepage" />
       </Helmet>
       <AppWrapper>
-        <span>My HomePage</span>
+        <NftCard />
       </AppWrapper>
     </>
   );

--- a/src/app/pages/HomePage/styles.ts
+++ b/src/app/pages/HomePage/styles.ts
@@ -4,6 +4,8 @@ import { StyleConstants } from 'styles/StyleConstants';
 export const AppWrapper = styled.div`
   width: 100%;
   height: calc(100vh - ${StyleConstants.NAV_BAR_HEIGHT});
+  padding: 0 1.5rem;
+  padding-top: 12rem;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   grid-template-rows: 1fr auto;

--- a/src/styles/theme/themes.ts
+++ b/src/styles/theme/themes.ts
@@ -2,8 +2,10 @@ export type Theme = {
   primary: string;
   brand: string;
   brandHover: string;
+  brandGradient: string;
   text: string;
   textSecondary: string;
+  textTertiary: string;
   background: string;
   backgroundVariant: string;
   backgroundGradient: string;
@@ -15,9 +17,13 @@ const darkTheme: Theme = {
   primary: 'rgba(28, 28, 40, 1)',
   brand: 'rgba(105, 102, 255, 1)',
   brandHover: 'rgba(123, 120, 255, 1)',
+  brandGradient: `
+    linear-gradient(325.79deg, #6966FF 24.5%, rgba(105, 102, 255, 0.36) 117.69%)
+  `,
   borderLight: 'rgba(241, 233, 231, 0.05)',
   text: 'rgba(255, 255, 255, 1)',
   textSecondary: 'rgba(200, 199, 216, 1)',
+  textTertiary: 'rgba(165, 158, 186, 1)',
   background: 'rgba(28, 28, 40, 1)',
   backgroundVariant: 'rgba(57, 57, 83, 1)',
   backgroundGradient: `

--- a/src/styles/theme/themes.ts
+++ b/src/styles/theme/themes.ts
@@ -11,6 +11,7 @@ export type Theme = {
   backgroundGradient: string;
   border: string;
   borderLight: string;
+  green: string;
 };
 
 const darkTheme: Theme = {
@@ -21,7 +22,7 @@ const darkTheme: Theme = {
     linear-gradient(325.79deg, #6966FF 24.5%, rgba(105, 102, 255, 0.36) 117.69%)
   `,
   borderLight: 'rgba(241, 233, 231, 0.05)',
-  text: 'rgba(255, 255, 255, 1)',
+  text: 'rgba(250, 249, 246, 1)',
   textSecondary: 'rgba(200, 199, 216, 1)',
   textTertiary: 'rgba(165, 158, 186, 1)',
   background: 'rgba(28, 28, 40, 1)',
@@ -33,6 +34,7 @@ const darkTheme: Theme = {
     linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0) 100%); 
     background-blend-mode: soft-light;
   `,
+  green: 'rgba(22, 181, 127, 1)',
 };
 
 export const themes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,667 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stdlib/array-float32@^0.0.x":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float32/-/array-float32-0.0.6.tgz#7a1c89db3c911183ec249fa32455abd9328cfa27"
+  integrity sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==
+  dependencies:
+    "@stdlib/assert-has-float32array-support" "^0.0.x"
+
+"@stdlib/array-float64@^0.0.x":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@stdlib/array-float64/-/array-float64-0.0.6.tgz#02d1c80dd4c38a0f1ec150ddfefe706e148bfc10"
+  integrity sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==
+  dependencies:
+    "@stdlib/assert-has-float64array-support" "^0.0.x"
+
+"@stdlib/assert-has-float32array-support@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.0.8.tgz#77371183726e26ca9e6f9db41d34543607074067"
+  integrity sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==
+  dependencies:
+    "@stdlib/assert-is-float32array" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/constants-float64-pinf" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/assert-has-float64array-support@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.0.8.tgz#4d154994d348f5d894f63b3fbb9d7a6e2e4e5311"
+  integrity sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==
+  dependencies:
+    "@stdlib/assert-is-float64array" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/assert-has-node-buffer-support@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-node-buffer-support/-/assert-has-node-buffer-support-0.0.8.tgz#5564d8e797c850f6ffc522b720eab1f6cba9c814"
+  integrity sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/assert-has-own-property@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-own-property/-/assert-has-own-property-0.0.7.tgz#8b55b38e25db8366b028cb871905ac09c9c253fb"
+  integrity sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==
+
+"@stdlib/assert-has-symbol-support@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.0.8.tgz#8606b247f0d023f2a7a6aa8a6fe5e346aa802a8f"
+  integrity sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==
+  dependencies:
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/assert-has-tostringtag-support@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.0.9.tgz#1080ef0a4be576a72d19a819498719265456f170"
+  integrity sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==
+  dependencies:
+    "@stdlib/assert-has-symbol-support" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/assert-has-utf16-surrogate-pair-at@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-has-utf16-surrogate-pair-at/-/assert-has-utf16-surrogate-pair-at-0.0.8.tgz#14876fa2ebc3b54dec12d1dbbaf132812f8689f1"
+  integrity sha512-GkkVSNgb/CCLExaBUHueNjnf6cdNpbNPFNZjHribp7Xo9Nqa/4lRJcVj/aLh0Pyr30BoAQ2hMHfbNyozwMX3mA==
+  dependencies:
+    "@stdlib/assert-is-nonnegative-integer" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+
+"@stdlib/assert-is-array@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-array/-/assert-is-array-0.0.7.tgz#7f30904f88a195d918c588540a6807d1ae639d79"
+  integrity sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-boolean@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-boolean/-/assert-is-boolean-0.0.8.tgz#6b38c2e799e4475d7647fb0e44519510e67080ce"
+  integrity sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-buffer@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-buffer/-/assert-is-buffer-0.0.8.tgz#633b98bc342979e9ed8ed71c3a0f1366782d1412"
+  integrity sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==
+  dependencies:
+    "@stdlib/assert-is-object-like" "^0.0.x"
+
+"@stdlib/assert-is-float32array@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float32array/-/assert-is-float32array-0.0.8.tgz#a43f6106a2ef8797496ab85aaf6570715394654a"
+  integrity sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-float64array@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-float64array/-/assert-is-float64array-0.0.8.tgz#8c27204ae6cf309e16f0bbad1937f8aa06c2a812"
+  integrity sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==
+  dependencies:
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-function@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-function/-/assert-is-function-0.0.8.tgz#e4925022b7dd8c4a67e86769691d1d29ab159db9"
+  integrity sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==
+  dependencies:
+    "@stdlib/utils-type-of" "^0.0.x"
+
+"@stdlib/assert-is-integer@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-integer/-/assert-is-integer-0.0.8.tgz#7a2b5778a9ec530a12031b6a6ff7c58c6892e50f"
+  integrity sha512-gCjuKGglSt0IftXJXIycLFNNRw0C+8235oN0Qnw3VAdMuEWauwkNhoiw0Zsu6Arzvud8MQJY0oBGZtvLUC6QzQ==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.0.x"
+    "@stdlib/constants-float64-ninf" "^0.0.x"
+    "@stdlib/constants-float64-pinf" "^0.0.x"
+    "@stdlib/math-base-assert-is-integer" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/assert-is-nonnegative-integer@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-nonnegative-integer/-/assert-is-nonnegative-integer-0.0.7.tgz#e6aa304dbca14020e87ea05687eccd696ef27035"
+  integrity sha512-+5SrGM3C1QRpzmi+JnyZF9QsH29DCkSONm2558yOTdfCLClYOXDs++ktQo/8baCBFSi9JnFaLXVt1w1sayQeEQ==
+  dependencies:
+    "@stdlib/assert-is-integer" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/assert-is-number@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-number/-/assert-is-number-0.0.7.tgz#82b07cda4045bd0ecc846d3bc26d39dca7041c61"
+  integrity sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.0.x"
+    "@stdlib/number-ctor" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-object-like@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object-like/-/assert-is-object-like-0.0.8.tgz#f6fc36eb7b612d650c6201d177214733426f0c56"
+  integrity sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==
+  dependencies:
+    "@stdlib/assert-tools-array-function" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/assert-is-object@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-object/-/assert-is-object-0.0.8.tgz#0220dca73bc3df044fc43e73b02963d5ef7ae489"
+  integrity sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.0.x"
+
+"@stdlib/assert-is-plain-object@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.0.7.tgz#0c3679faf61b03023363f1ce30f8d00f8ed1c37b"
+  integrity sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.0.x"
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/assert-is-object" "^0.0.x"
+    "@stdlib/utils-get-prototype-of" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-regexp-string@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-regexp-string/-/assert-is-regexp-string-0.0.9.tgz#424f77b4aaa46a19f4b60ba4b671893a2e5df066"
+  integrity sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/regexp-eol" "^0.0.x"
+    "@stdlib/regexp-regexp" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+
+"@stdlib/assert-is-regexp@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-regexp/-/assert-is-regexp-0.0.7.tgz#430fe42417114e7ea01d21399a70ed9c4cbae867"
+  integrity sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-is-string@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-is-string/-/assert-is-string-0.0.8.tgz#b07e4a4cbd93b13d38fa5ebfaa281ccd6ae9e43f"
+  integrity sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==
+  dependencies:
+    "@stdlib/assert-has-tostringtag-support" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/assert-tools-array-function@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.0.7.tgz#34e9e5a3fca62ea75da99fc9995ba845ba514988"
+  integrity sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==
+  dependencies:
+    "@stdlib/assert-is-array" "^0.0.x"
+
+"@stdlib/buffer-ctor@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/buffer-ctor/-/buffer-ctor-0.0.7.tgz#d05b7f4a6ef26defe6cdd41ca244a927b96c55ec"
+  integrity sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==
+  dependencies:
+    "@stdlib/assert-has-node-buffer-support" "^0.0.x"
+
+"@stdlib/buffer-from-string@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/buffer-from-string/-/buffer-from-string-0.0.8.tgz#0901a6e66c278db84836e483a7278502e2a33994"
+  integrity sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/buffer-ctor" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+
+"@stdlib/cli-ctor@^0.0.x":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/cli-ctor/-/cli-ctor-0.0.3.tgz#5b0a6d253217556c778015eee6c14be903f82c2b"
+  integrity sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-noop" "^0.0.x"
+    minimist "^1.2.0"
+
+"@stdlib/complex-float32@^0.0.7", "@stdlib/complex-float32@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float32/-/complex-float32-0.0.7.tgz#fb9a0c34254eaf3ed91c39983e19ef131fc18bc1"
+  integrity sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.0.x"
+    "@stdlib/number-float64-base-to-float32" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-define-property" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/complex-float64@^0.0.8", "@stdlib/complex-float64@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-float64/-/complex-float64-0.0.8.tgz#00ee3a0629d218a01b830a20406aea7d7aff6fb3"
+  integrity sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==
+  dependencies:
+    "@stdlib/assert-is-number" "^0.0.x"
+    "@stdlib/complex-float32" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+    "@stdlib/utils-define-property" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/complex-reim@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-reim/-/complex-reim-0.0.6.tgz#9657971e36f2a1f1930a21249c1934c8c5087efd"
+  integrity sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==
+  dependencies:
+    "@stdlib/array-float64" "^0.0.x"
+    "@stdlib/complex-float64" "^0.0.x"
+    "@stdlib/types" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/complex-reimf@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@stdlib/complex-reimf/-/complex-reimf-0.0.1.tgz#6797bc1bfb668a30511611f2544d0cff4d297775"
+  integrity sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==
+  dependencies:
+    "@stdlib/array-float32" "^0.0.x"
+    "@stdlib/complex-float32" "^0.0.x"
+    "@stdlib/types" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/constants-float64-ninf@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.0.8.tgz#4a83691d4d46503e2339fa3ec21d0440877b5bb7"
+  integrity sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==
+  dependencies:
+    "@stdlib/number-ctor" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/constants-float64-pinf@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.0.8.tgz#ad3d5b267b142b0927363f6eda74c94b8c4be8bf"
+  integrity sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==
+  dependencies:
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/fs-exists@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-exists/-/fs-exists-0.0.8.tgz#391b2cee3e014a3b20266e5d047847f68ef82331"
+  integrity sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==
+  dependencies:
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-cwd" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/fs-read-file@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-read-file/-/fs-read-file-0.0.8.tgz#2f12669fa6dd2d330fb5006a94dc8896f0aaa0e0"
+  integrity sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==
+  dependencies:
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/fs-resolve-parent-path@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.0.8.tgz#628119952dfaae78afe3916dca856408a4f5c1eb"
+  integrity sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.0.x"
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/assert-is-plain-object" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-exists" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-cwd" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/math-base-assert-is-integer@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-assert-is-integer/-/math-base-assert-is-integer-0.0.7.tgz#d70faf41bed1bd737333877eb21660bf0ee779df"
+  integrity sha512-swIEKQJZOwzacYDiX5SSt5/nHd6PYJkLlVKZiVx/GCpflstQnseWA0TmudG7XU5HJnxDGV/w6UL02dEyBH7VEw==
+  dependencies:
+    "@stdlib/math-base-special-floor" "^0.0.x"
+
+"@stdlib/math-base-napi-unary@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.0.9.tgz#3a70fa64128aca7011c5a477110d2682d06c8ea8"
+  integrity sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==
+  dependencies:
+    "@stdlib/complex-float32" "^0.0.7"
+    "@stdlib/complex-float64" "^0.0.8"
+    "@stdlib/complex-reim" "^0.0.6"
+    "@stdlib/complex-reimf" "^0.0.1"
+    "@stdlib/utils-library-manifest" "^0.0.8"
+
+"@stdlib/math-base-special-floor@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-floor/-/math-base-special-floor-0.0.8.tgz#c0bbde6f984aa132917a47c8bcc71b31ed0cbf26"
+  integrity sha512-VwpaiU0QhQKB8p+r9p9mNzhrjU5ZVBnUcLjKNCDADiGNvO5ACI/I+W++8kxBz5XSp5PAQhaFCH4MpRM1tSkd/w==
+  dependencies:
+    "@stdlib/math-base-napi-unary" "^0.0.x"
+    "@stdlib/utils-library-manifest" "^0.0.x"
+
+"@stdlib/math-base-special-round@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/math-base-special-round/-/math-base-special-round-0.0.7.tgz#86c1d6570cc380b658859725903016aa8044c271"
+  integrity sha512-uFPWDru18ouUFD5/TQzm3fNzds/IlQbpQXjUBjIDpxN9PizneZLZSNNYg6ECq+FQv8WK1CQmyj10bu2zLReqGQ==
+
+"@stdlib/number-ctor@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-ctor/-/number-ctor-0.0.7.tgz#e97a66664639c9853b6c80bc7a15f7d67a2fc991"
+  integrity sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==
+
+"@stdlib/number-float64-base-to-float32@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.0.7.tgz#c7b82bb26cb7404017ede32cebe5864fd84c0e35"
+  integrity sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==
+  dependencies:
+    "@stdlib/array-float32" "^0.0.x"
+
+"@stdlib/process-cwd@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/process-cwd/-/process-cwd-0.0.8.tgz#5eef63fb75ffb5fc819659d2f450fa3ee2aa10bf"
+  integrity sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==
+  dependencies:
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+
+"@stdlib/process-read-stdin@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/process-read-stdin/-/process-read-stdin-0.0.7.tgz#684ad531759c6635715a67bdd8721fc249baa200"
+  integrity sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/buffer-ctor" "^0.0.x"
+    "@stdlib/buffer-from-string" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/utils-next-tick" "^0.0.x"
+
+"@stdlib/regexp-eol@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-eol/-/regexp-eol-0.0.7.tgz#cf1667fdb5da1049c2c2f8d5c47dcbaede8650a4"
+  integrity sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.0.x"
+    "@stdlib/assert-is-boolean" "^0.0.x"
+    "@stdlib/assert-is-plain-object" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/regexp-extended-length-path@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.0.7.tgz#7f76641c29895771e6249930e1863e7e137a62e0"
+  integrity sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/regexp-function-name@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-function-name/-/regexp-function-name-0.0.7.tgz#e8dc6c7fe9276f0a8b4bc7f630a9e32ba9f37250"
+  integrity sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/regexp-regexp@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/regexp-regexp/-/regexp-regexp-0.0.8.tgz#50221b52088cd427ef19fae6593977c1c3f77e87"
+  integrity sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/streams-node-stdin@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/streams-node-stdin/-/streams-node-stdin-0.0.7.tgz#65ff09a2140999702a1ad885e6505334d947428f"
+  integrity sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==
+
+"@stdlib/string-base-format-interpolate@^0.0.x":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.0.4.tgz#297eeb23c76f745dcbb3d9dbd24e316773944538"
+  integrity sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==
+
+"@stdlib/string-base-format-tokenize@^0.0.x":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.0.4.tgz#c1fc612ee0c0de5516dbf083e88c11d14748c30e"
+  integrity sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==
+
+"@stdlib/string-code-point-at@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-code-point-at/-/string-code-point-at-0.0.9.tgz#c3124f6cbad906acffb6a8145ce7f986ae074f78"
+  integrity sha512-3RFLlPUyFsFakI46/MHNt2QpByZvhM0RdszOtJylg6QgZFs0u5PQMkw5+rkAZ0phPyw81kpuEOSQcntzYw+h6g==
+  dependencies:
+    "@stdlib/assert-is-boolean" "^0.0.x"
+    "@stdlib/assert-is-nonnegative-integer" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+
+"@stdlib/string-format@^0.0.x":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-format/-/string-format-0.0.3.tgz#e916a7be14d83c83716f5d30b1b1af94c4e105b9"
+  integrity sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==
+  dependencies:
+    "@stdlib/string-base-format-interpolate" "^0.0.x"
+    "@stdlib/string-base-format-tokenize" "^0.0.x"
+
+"@stdlib/string-lowercase@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-lowercase/-/string-lowercase-0.0.9.tgz#487361a10364bd0d9b5ee44f5cc654c7da79b66d"
+  integrity sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+
+"@stdlib/string-next-grapheme-cluster-break@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-next-grapheme-cluster-break/-/string-next-grapheme-cluster-break-0.0.9.tgz#cf8c6b57bc8e58986b04452b291da6e7ca3854c5"
+  integrity sha512-R30hWf/aaJUiDMlXNZdB3PIaNJYZ76czyrUN9+bBH5b7cqxcjbBndEVowqm9eNGqb4mTrgWgxkvVqSoXXamE5Q==
+  dependencies:
+    "@stdlib/assert-has-utf16-surrogate-pair-at" "^0.0.x"
+    "@stdlib/assert-is-integer" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-code-point-at" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+    "@stdlib/string-tools-grapheme-cluster-break" "^0.0.x"
+
+"@stdlib/string-num-grapheme-clusters@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-num-grapheme-clusters/-/string-num-grapheme-clusters-0.0.9.tgz#03d1ac215529f489281a41835607049134c9dc87"
+  integrity sha512-MJBlwPOmWmBJh//dAxeik9EfFf/ehLf/xEki2r0O337x3c7U93Qty0O2/4RwFZyxBf5bUoM9u7SQ6uUg9qCTgQ==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/regexp-eol" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+    "@stdlib/string-next-grapheme-cluster-break" "^0.0.x"
+
+"@stdlib/string-replace@^0.0.x":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-replace/-/string-replace-0.0.11.tgz#5e8790cdf4d9805ab78cc5798ab3d364dfbf5016"
+  integrity sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/assert-is-regexp" "^0.0.x"
+    "@stdlib/assert-is-regexp-string" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/regexp-eol" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+    "@stdlib/utils-escape-regexp-string" "^0.0.x"
+    "@stdlib/utils-regexp-from-string" "^0.0.x"
+
+"@stdlib/string-tools-grapheme-cluster-break@^0.0.x":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-tools-grapheme-cluster-break/-/string-tools-grapheme-cluster-break-0.0.3.tgz#b314dd93e3bd56e4b0d81cb915c633199ff488f1"
+  integrity sha512-lkGlk6fB8kLej4ir2X8oNmTKTY6lfwbzBD7Ym8FKEo0OGm1ZcDhTOcr123eBMCxjOjE6dv7mMMoIrWVRLjk0ew==
+  dependencies:
+    "@stdlib/utils-define-nonenumerable-read-only-property" "^0.0.x"
+
+"@stdlib/string-truncate-middle@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@stdlib/string-truncate-middle/-/string-truncate-middle-0.0.3.tgz#b120c977844d37cf71d6ecfb5534a2735ef232dd"
+  integrity sha512-AIF8swqtSNbSCtjHJgSsm90CSiW3u/qLSqFBTyVUASt+thsfJFQbnABukyO9jvw0h9ramuTR4SuMws+MAvicug==
+  dependencies:
+    "@stdlib/assert-is-nonnegative-integer" "^0.0.x"
+    "@stdlib/assert-is-regexp-string" "^0.0.x"
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/math-base-special-floor" "^0.0.x"
+    "@stdlib/math-base-special-round" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/regexp-eol" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+    "@stdlib/string-next-grapheme-cluster-break" "^0.0.x"
+    "@stdlib/string-num-grapheme-clusters" "^0.0.x"
+    "@stdlib/types" "^0.0.x"
+    "@stdlib/utils-regexp-from-string" "^0.0.x"
+
+"@stdlib/types@^0.0.x":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@stdlib/types/-/types-0.0.14.tgz#02d3aab7a9bfaeb86e34ab749772ea22f7b2f7e0"
+  integrity sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==
+
+"@stdlib/utils-constructor-name@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-constructor-name/-/utils-constructor-name-0.0.8.tgz#ef63d17466c555b58b348a0c1175cee6044b8848"
+  integrity sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==
+  dependencies:
+    "@stdlib/assert-is-buffer" "^0.0.x"
+    "@stdlib/regexp-function-name" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/utils-convert-path@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-convert-path/-/utils-convert-path-0.0.8.tgz#a959d02103eee462777d222584e72eceef8c223b"
+  integrity sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-read-file" "^0.0.x"
+    "@stdlib/process-read-stdin" "^0.0.x"
+    "@stdlib/regexp-eol" "^0.0.x"
+    "@stdlib/regexp-extended-length-path" "^0.0.x"
+    "@stdlib/streams-node-stdin" "^0.0.x"
+    "@stdlib/string-lowercase" "^0.0.x"
+    "@stdlib/string-replace" "^0.0.x"
+
+"@stdlib/utils-define-nonenumerable-read-only-property@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.0.7.tgz#ee74540c07bfc3d997ef6f8a1b2df267ea0c07ca"
+  integrity sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==
+  dependencies:
+    "@stdlib/types" "^0.0.x"
+    "@stdlib/utils-define-property" "^0.0.x"
+
+"@stdlib/utils-define-property@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-define-property/-/utils-define-property-0.0.9.tgz#2f40ad66e28099714e3774f3585db80b13816e76"
+  integrity sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==
+  dependencies:
+    "@stdlib/types" "^0.0.x"
+
+"@stdlib/utils-escape-regexp-string@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.0.9.tgz#36f25d78b2899384ca6c97f4064a8b48edfedb6e"
+  integrity sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+
+"@stdlib/utils-get-prototype-of@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.0.7.tgz#f677132bcbc0ec89373376637148d364435918df"
+  integrity sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==
+  dependencies:
+    "@stdlib/assert-is-function" "^0.0.x"
+    "@stdlib/utils-native-class" "^0.0.x"
+
+"@stdlib/utils-global@^0.0.x":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-global/-/utils-global-0.0.7.tgz#0d99dcd11b72ad10b97dfb43536ff50436db6fb4"
+  integrity sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==
+  dependencies:
+    "@stdlib/assert-is-boolean" "^0.0.x"
+
+"@stdlib/utils-library-manifest@^0.0.8", "@stdlib/utils-library-manifest@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-library-manifest/-/utils-library-manifest-0.0.8.tgz#61d3ed283e82c8f14b7f952d82cfb8e47d036825"
+  integrity sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==
+  dependencies:
+    "@stdlib/cli-ctor" "^0.0.x"
+    "@stdlib/fs-resolve-parent-path" "^0.0.x"
+    "@stdlib/utils-convert-path" "^0.0.x"
+    debug "^2.6.9"
+    resolve "^1.1.7"
+
+"@stdlib/utils-native-class@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-native-class/-/utils-native-class-0.0.8.tgz#2e79de97f85d88a2bb5baa7a4528add71448d2be"
+  integrity sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==
+  dependencies:
+    "@stdlib/assert-has-own-property" "^0.0.x"
+    "@stdlib/assert-has-tostringtag-support" "^0.0.x"
+
+"@stdlib/utils-next-tick@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-next-tick/-/utils-next-tick-0.0.8.tgz#72345745ec3b3aa2cedda056338ed95daae9388c"
+  integrity sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==
+
+"@stdlib/utils-noop@^0.0.x":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-noop/-/utils-noop-0.0.14.tgz#8a2077fae0877c4c9e4c5f72f3c9284ca109d4c3"
+  integrity sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==
+
+"@stdlib/utils-regexp-from-string@^0.0.x":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-regexp-from-string/-/utils-regexp-from-string-0.0.9.tgz#fe4745a9a000157b365971c513fd7d4b2cb9ad6e"
+  integrity sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==
+  dependencies:
+    "@stdlib/assert-is-string" "^0.0.x"
+    "@stdlib/regexp-regexp" "^0.0.x"
+    "@stdlib/string-format" "^0.0.x"
+
+"@stdlib/utils-type-of@^0.0.x":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@stdlib/utils-type-of/-/utils-type-of-0.0.8.tgz#c62ed3fcf629471fe80d83f44c4e325860109cbe"
+  integrity sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==
+  dependencies:
+    "@stdlib/utils-constructor-name" "^0.0.x"
+    "@stdlib/utils-global" "^0.0.x"
+
 "@surma/rollup-plugin-off-main-thread@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz#ee34985952ca21558ab0d952f00298ad2190c053"
@@ -4313,7 +4974,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==


### PR DESCRIPTION
## Description

Implements the NFT auction card as seen in the Figma design.

## Test plan

- [ ] - clone `nft-card` branch
- [ ] - start app `yarn start
- [ ] - assert that you see a card on the home page
- [ ] - assert that the card contains prefilled nft information and an image.

## Example
User should see the following on the home page:
![image](https://user-images.githubusercontent.com/24196928/230822035-35407c7d-fec6-4f01-ae7f-66d0dd2bd897.png)
